### PR TITLE
Making the newly spawned arrows conform to the selected color and alpha

### DIFF
--- a/src/pose_with_covariance_array/display.cpp
+++ b/src/pose_with_covariance_array/display.cpp
@@ -141,6 +141,11 @@ void Display::onInitialize() {
     // TODO: is it safe to change Arrow to point in +X direction?
     d.arrow_->setOrientation(Ogre::Quaternion(Ogre::Degree(-90), Ogre::Vector3::UNIT_Y));
 
+    Ogre::ColourValue color = color_property_->getOgreColor();
+    color.a                 = alpha_property_->getFloat();
+    d.arrow_->setColor(color);
+      
+
     d.axes_ = boost::make_shared<rviz::Axes>(scene_manager_, scene_node_, axes_length_property_->getFloat(), axes_radius_property_->getFloat());
 
     d.covariance_ = covariance_property_->createAndPushBackVisual(scene_manager_, scene_node_);
@@ -260,6 +265,10 @@ void Display::processMessage(const mrs_msgs::PoseWithCovarianceArrayStamped::Con
 
     d.arrow_ = boost::make_shared<rviz::Arrow>(scene_manager_, scene_node_, shaft_length_property_->getFloat(), shaft_radius_property_->getFloat(),
                                           head_length_property_->getFloat(), head_radius_property_->getFloat());
+
+    Ogre::ColourValue color = color_property_->getOgreColor();
+    color.a                 = alpha_property_->getFloat();
+    d.arrow_->setColor(color);
 
     d.axes_ = boost::make_shared<rviz::Axes>(scene_manager_, scene_node_, axes_length_property_->getFloat(), axes_radius_property_->getFloat());
 


### PR DESCRIPTION
Self-explanatory. Since the PoseWithCovarianceArray messages create a new set of dipslay elements (as opposed to modifying previous) on each received message, if the display shape is Arrow, they need to be re-colored upon creation. Otherwise they revert to white on each new message.