### PR TITLE
Faster pose_with_covariance_array display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(LIBRARIES
   MrsRvizPlugins_Bumper
   MrsRvizPlugins_Covariance
   MrsRvizPlugins_FastArrow
+  MrsRvizPlugins_SmartLine
   MrsRvizPlugins_NavGoal
   MrsRvizPlugins_PoseEstimate
   MrsRvizPlugins_Sphere

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_definitions("-Wno-register")
 set(LIBRARIES
   MrsRvizPlugins_Bumper
   MrsRvizPlugins_Covariance
+  MrsRvizPlugins_FastArrow
   MrsRvizPlugins_NavGoal
   MrsRvizPlugins_PoseEstimate
   MrsRvizPlugins_Sphere
@@ -124,6 +125,41 @@ target_link_libraries(MrsRvizPlugins_Covariance
   ${catkin_LIBRARIES}
   )
 
+## SMART LINE
+
+add_library(MrsRvizPlugins_SmartLine
+  include/smart_line/smart_line.h
+  src/smart_line/smart_line.cpp
+  )
+
+add_dependencies(MrsRvizPlugins_SmartLine
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS}
+  )
+
+target_link_libraries(MrsRvizPlugins_SmartLine
+  ${QT_LIBRARIES}
+  ${catkin_LIBRARIES}
+  )
+
+## FAST ARROW
+
+add_library(MrsRvizPlugins_FastArrow
+  include/fast_arrow/fast_arrow.h
+  src/fast_arrow/fast_arrow.cpp
+  )
+
+add_dependencies(MrsRvizPlugins_FastArrow
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS}
+  )
+
+target_link_libraries(MrsRvizPlugins_FastArrow
+  ${QT_LIBRARIES}
+  ${catkin_LIBRARIES}
+  MrsRvizPlugins_SmartLine
+  )
+
 ## POSE WITH COVARIANCE ARRAY
 
 add_library(MrsRvizPlugins_PoseWithCovarianceArray
@@ -140,6 +176,7 @@ target_link_libraries(MrsRvizPlugins_PoseWithCovarianceArray
   ${QT_LIBRARIES}
   ${catkin_LIBRARIES}
   MrsRvizPlugins_Covariance
+  MrsRvizPlugins_FastArrow
   )
 
 ## RVIZ NAV GOAL

--- a/include/fast_arrow/fast_arrow.h
+++ b/include/fast_arrow/fast_arrow.h
@@ -1,0 +1,67 @@
+#include <rviz/ogre_helpers/object.h>
+#include "smart_line/smart_line.h"
+ 
+ #ifndef FAST_ARROW_H
+ #define FAST_ARROW_H
+ 
+ namespace Ogre
+ {
+ class SceneManager;
+ class SceneNode;
+ class Vector3;
+ class Quaternion;
+ class ColourValue;
+ class Any;
+ } // namespace Ogre
+ 
+ namespace rviz
+ {
+ class Shape;
+ 
+ class FastArrow : public Object
+ {
+ public:
+   FastArrow(Ogre::SceneManager* scene_manager,
+         Ogre::SceneNode* parent_node = nullptr,
+         float shaft_length = 1.0f,
+         float head_length = 0.3f,
+         float head_diameter = 0.2f);
+   ~FastArrow() override;
+ 
+   void set(float shaft_length, float head_length, float head_diameter);
+ 
+   void setColor(float r, float g, float b, float a) override;
+   void setColor(const Ogre::ColourValue& color);
+ 
+   void setOrientation(const Ogre::Quaternion& orientation) override;
+ 
+   void setPosition(const Ogre::Vector3& position) override;
+ 
+   void setDirection(const Ogre::Vector3& direction);
+ 
+   void setScale(const Ogre::Vector3& scale) override;
+   const Ogre::Vector3& getPosition() override;
+   const Ogre::Quaternion& getOrientation() override;
+ 
+   Ogre::SceneNode* getSceneNode()
+   {
+     return scene_node_;
+   }
+
+   rviz::SmartLine* getShaft();
+   rviz::SmartLine* getHeadL();
+   rviz::SmartLine* getHeadR();
+ 
+   void setUserData(const Ogre::Any& data) override;
+ 
+ private:
+   Ogre::SceneNode* scene_node_;
+ 
+   rviz::SmartLine* shaft_;
+   rviz::SmartLine* head_l_;
+   rviz::SmartLine* head_r_;
+ };
+ 
+ } // namespace rviz
+ 
+ #endif /* FAST_ARROW_H */

--- a/include/pose_with_covariance_array/display.h
+++ b/include/pose_with_covariance_array/display.h
@@ -11,6 +11,8 @@
 #include <covariance/property.h>
 #include <covariance/visual.h>
 
+#include <fast_arrow/fast_arrow.h>
+
 namespace rviz
 {
 class Arrow;
@@ -32,6 +34,7 @@ struct display_object
 {
   boost::shared_ptr<rviz::Arrow> arrow_;
   boost::shared_ptr<rviz::Axes> axes_;
+  boost::shared_ptr<rviz::FastArrow> fast_arrow_;
   boost::shared_ptr<mrs_rviz_plugins::covariance::Visual> covariance_;
 };
 
@@ -44,6 +47,7 @@ public:
   {
     Arrow,
     Axes,
+    FastArrow,
   };
 
   Display();

--- a/include/smart_line/smart_line.h
+++ b/include/smart_line/smart_line.h
@@ -1,0 +1,18 @@
+ #ifndef SMART_LINE_H_
+ #define SMART_LINE_H_
+ 
+#include <rviz/ogre_helpers/line.h>
+
+ namespace rviz
+ {
+ class SmartLine : public Line
+ {
+ public:
+   using Line::Line; //inherited constructor
+   void setColorUnshaded(const Ogre::ColourValue& c);
+
+ };
+ 
+ } // namespace rviz
+ 
+ #endif /* SMART_LINE_H_ */

--- a/src/fast_arrow/fast_arrow.cpp
+++ b/src/fast_arrow/fast_arrow.cpp
@@ -1,0 +1,125 @@
+ #include "fast_arrow/fast_arrow.h"
+
+#include <rviz/ogre_helpers/shape.h>
+ 
+ #include <OgreSceneManager.h>
+ #include <OgreSceneNode.h>
+ #include <OgreVector3.h>
+ #include <OgreQuaternion.h>
+ 
+ #include <sstream>
+ 
+ namespace rviz
+ {
+ FastArrow::FastArrow(Ogre::SceneManager* scene_manager,
+              Ogre::SceneNode* parent_node,
+              float shaft_length,
+              float head_length,
+              float head_diameter)
+   : Object(scene_manager)
+ {
+   if (!parent_node)
+   {
+     parent_node = scene_manager_->getRootSceneNode();
+   }
+ 
+   scene_node_ = parent_node->createChildSceneNode();
+ 
+   shaft_   = new rviz::SmartLine(scene_manager_, scene_node_);
+   head_l_  = new rviz::SmartLine(scene_manager_, scene_node_);
+   head_r_  = new rviz::SmartLine(scene_manager_, scene_node_);
+
+   set(shaft_length, head_length, head_diameter);
+ 
+   setOrientation(Ogre::Quaternion::IDENTITY);
+ }
+ 
+ FastArrow::~FastArrow()
+ {
+   delete shaft_;
+   delete head_l_;
+   delete head_r_;
+ 
+   scene_manager_->destroySceneNode(scene_node_->getName());
+ }
+ 
+ void FastArrow::set(float shaft_length, float head_length, float head_diameter)
+ {
+   shaft_->setPoints(Ogre::Vector3(0,0,0), Ogre::Vector3(0, shaft_length, 0));
+   head_l_->setPoints(Ogre::Vector3(0,shaft_length,0), Ogre::Vector3(0, shaft_length-head_length,  head_diameter/2));
+   head_r_->setPoints(Ogre::Vector3(0,shaft_length,0), Ogre::Vector3(0, shaft_length-head_length, -head_diameter/2));
+   /* shaft_->setPosition(Ogre::Vector3(0.0f, shaft_length / 2.0f, 0.0f)); */
+ 
+   /* head_->setScale(Ogre::Vector3(head_diameter, head_length, head_diameter)); */
+   /* head_->setPosition(Ogre::Vector3(0.0f, shaft_length, 0.0f)); */
+ }
+ 
+ void FastArrow::setColor(const Ogre::ColourValue& c)
+ {
+   shaft_->setColorUnshaded(c);
+   /* shaft_->manual_object_material_->getTechique(0)->setAmbient(1,1,1); */
+   head_l_->setColorUnshaded(c);
+   /* head_l_->manual_object_material_->getTechique(0)->setAmbient(1,1,1); */
+   head_r_->setColorUnshaded(c);
+   /* head_r_->manual_object_material_->getTechique(0)->setAmbient(1,1,1); */
+ }
+ 
+ void FastArrow::setColor(float r, float g, float b, float a)
+ {
+   setColor(Ogre::ColourValue(r, g, b, a));
+ }
+ 
+ void FastArrow::setPosition(const Ogre::Vector3& position)
+ {
+   scene_node_->setPosition(position);
+ }
+ 
+ void FastArrow::setOrientation(const Ogre::Quaternion& orientation)
+ {
+   // "forward" (negative z) should always be our identity orientation
+   // ... wouldn't need to mangle the orientation if we just fix the cylinders!
+   scene_node_->setOrientation(orientation * Ogre::Quaternion(Ogre::Degree(-90), Ogre::Vector3::UNIT_X));
+ }
+ 
+ void FastArrow::setDirection(const Ogre::Vector3& direction)
+ {
+   if (!direction.isZeroLength())
+   {
+     setOrientation(Ogre::Vector3::NEGATIVE_UNIT_Z.getRotationTo(direction));
+   }
+ }
+ 
+ void FastArrow::setScale(const Ogre::Vector3& scale)
+ {
+   // Have to mangle the scale because of the default orientation of the cylinders :(
+   scene_node_->setScale(Ogre::Vector3(scale.z, scale.x, scale.y));
+ }
+ 
+ const Ogre::Vector3& FastArrow::getPosition()
+ {
+   return scene_node_->getPosition();
+ }
+ 
+ const Ogre::Quaternion& FastArrow::getOrientation()
+ {
+   return scene_node_->getOrientation();
+ }
+
+ rviz::SmartLine* FastArrow::getShaft(){
+   return shaft_;
+ }
+ rviz::SmartLine* FastArrow::getHeadL(){
+   return head_l_;
+ }
+ rviz::SmartLine* FastArrow::getHeadR(){
+   return head_l_;
+ }
+ 
+ void FastArrow::setUserData(const Ogre::Any& data)
+ {
+   shaft_->setUserData(data);
+   head_l_->setUserData(data);
+   head_r_->setUserData(data);
+ }
+ 
+ } // namespace rviz

--- a/src/pose_with_covariance_array/display.cpp
+++ b/src/pose_with_covariance_array/display.cpp
@@ -232,7 +232,8 @@ void Display::updateShapeVisibility() {
       if (d.fast_arrow_)
         d.fast_arrow_->getSceneNode()->setVisible(false);
 
-      d.covariance_->setVisible(false);
+      if (d.covariance_)
+        d.covariance_->setVisible(false);
     }
   } else {
     /* bool use_arrow = (shape_property_->getOptionInt() == Arrow); */

--- a/src/pose_with_covariance_array/display.cpp
+++ b/src/pose_with_covariance_array/display.cpp
@@ -23,6 +23,7 @@
 #include <covariance/visual.h>
 #include <covariance/property.h>
 
+
 #include <Eigen/Dense>
 
 namespace mrs_rviz_plugins
@@ -65,11 +66,16 @@ public:
         if (display_->shape_property_->getOptionInt() == Display::Arrow) {
           aabbs.push_back(cur_pose.arrow_->getHead()->getEntity()->getWorldBoundingBox());
           aabbs.push_back(cur_pose.arrow_->getShaft()->getEntity()->getWorldBoundingBox());
-        } else {
+        } else if (display_->shape_property_->getOptionInt() == Display::Axes) {
           aabbs.push_back(cur_pose.axes_->getXShape()->getEntity()->getWorldBoundingBox());
           aabbs.push_back(cur_pose.axes_->getYShape()->getEntity()->getWorldBoundingBox());
           aabbs.push_back(cur_pose.axes_->getZShape()->getEntity()->getWorldBoundingBox());
         }
+        /* else { */
+        /*   aabbs.push_back(cur_pose.fast_arrow_->getShaft()->getEntity()->getWorldBoundingBox()); */
+        /*   aabbs.push_back(cur_pose.fast_arrow_->getHeadL()->getEntity()->getWorldBoundingBox()); */
+        /*   aabbs.push_back(cur_pose.fast_arrow_->getHeadR()->getEntity()->getWorldBoundingBox()); */
+        /* } */
 
         if (display_->covariance_property_->getBool()) {
           if (display_->covariance_property_->getPositionBool()) {
@@ -102,9 +108,10 @@ private:
 };
 
 Display::Display() : pose_valid_(false) {
-  shape_property_ = std::make_unique<rviz::EnumProperty>("Shape", "Arrow", "Shape to display the pose as.", this, SLOT(updateShapeChoice()));
+  shape_property_ = std::make_unique<rviz::EnumProperty>("Shape", "FastArrow", "Shape to display the pose as.", this, SLOT(updateShapeChoice()));
   shape_property_->addOption("Arrow", Arrow);
   shape_property_->addOption("Axes", Axes);
+  shape_property_->addOption("FastArrow", FastArrow);
 
   color_property_ = std::make_unique<rviz::ColorProperty>("Color", QColor(255, 25, 0), "Color to draw the arrow.", this, SLOT(updateColorAndAlpha()));
 
@@ -144,9 +151,12 @@ void Display::onInitialize() {
     Ogre::ColourValue color = color_property_->getOgreColor();
     color.a                 = alpha_property_->getFloat();
     d.arrow_->setColor(color);
-      
 
     d.axes_ = boost::make_shared<rviz::Axes>(scene_manager_, scene_node_, axes_length_property_->getFloat(), axes_radius_property_->getFloat());
+
+    d.fast_arrow_ = boost::make_shared<rviz::FastArrow>(scene_manager_, scene_node_, shaft_length_property_->getFloat(), head_length_property_->getFloat(),
+                                        head_radius_property_->getFloat());
+    d.fast_arrow_->setColor(color);
 
     d.covariance_ = covariance_property_->createAndPushBackVisual(scene_manager_, scene_node_);
 
@@ -172,6 +182,7 @@ void Display::updateColorAndAlpha() {
 
   for (auto& d : disp_data) {
     d.arrow_->setColor(color);
+    d.fast_arrow_->setColor(color);
   }
 
   context_->queueRender();
@@ -180,6 +191,7 @@ void Display::updateColorAndAlpha() {
 void Display::updateArrowGeometry() {
   for (auto& d : disp_data) {
     d.arrow_->set(shaft_length_property_->getFloat(), shaft_radius_property_->getFloat(), head_length_property_->getFloat(), head_radius_property_->getFloat());
+    d.fast_arrow_->set(shaft_length_property_->getFloat(), head_length_property_->getFloat(), head_radius_property_->getFloat());
   }
   context_->queueRender();
 }
@@ -192,12 +204,13 @@ void Display::updateAxisGeometry() {
 }
 
 void Display::updateShapeChoice() {
-  bool use_arrow = (shape_property_->getOptionInt() == Arrow);
+  bool use_mesh_arrow = (shape_property_->getOptionInt() == FastArrow);
+  bool use_arrow = use_mesh_arrow || (shape_property_->getOptionInt() == FastArrow);
 
   color_property_->setHidden(!use_arrow);
   alpha_property_->setHidden(!use_arrow);
   shaft_length_property_->setHidden(!use_arrow);
-  shaft_radius_property_->setHidden(!use_arrow);
+  shaft_radius_property_->setHidden(!use_mesh_arrow);
   head_length_property_->setHidden(!use_arrow);
   head_radius_property_->setHidden(!use_arrow);
 
@@ -212,15 +225,43 @@ void Display::updateShapeChoice() {
 void Display::updateShapeVisibility() {
   if (!pose_valid_) {
     for (auto& d : disp_data) {
-      d.arrow_->getSceneNode()->setVisible(false);
-      d.axes_->getSceneNode()->setVisible(false);
+      if (d.arrow_)
+        d.arrow_->getSceneNode()->setVisible(false);
+      if (d.axes_)
+        d.axes_->getSceneNode()->setVisible(false);
+      if (d.fast_arrow_)
+        d.fast_arrow_->getSceneNode()->setVisible(false);
+
       d.covariance_->setVisible(false);
     }
   } else {
-    bool use_arrow = (shape_property_->getOptionInt() == Arrow);
+    /* bool use_arrow = (shape_property_->getOptionInt() == Arrow); */
     for (auto& d : disp_data) {
-      d.arrow_->getSceneNode()->setVisible(use_arrow);
-      d.axes_->getSceneNode()->setVisible(!use_arrow);
+      switch (shape_property_->getOptionInt()){
+        case (Arrow):
+          if (d.arrow_)
+            d.arrow_->getSceneNode()->setVisible(true);
+          if (d.axes_)
+            d.axes_->getSceneNode()->setVisible(false);
+          if (d.fast_arrow_)
+            d.fast_arrow_->getSceneNode()->setVisible(false);
+          break;
+        case (Axes):
+          if (d.arrow_)
+            d.arrow_->getSceneNode()->setVisible(false);
+          if (d.axes_)
+            d.axes_->getSceneNode()->setVisible(true);
+          if (d.fast_arrow_)
+            d.fast_arrow_->getSceneNode()->setVisible(false);
+          break;
+        default:
+          if (d.arrow_)
+            d.arrow_->getSceneNode()->setVisible(false);
+          if (d.axes_)
+            d.axes_->getSceneNode()->setVisible(false);
+          if (d.fast_arrow_)
+            d.fast_arrow_->getSceneNode()->setVisible(true);
+      }
     }
     covariance_property_->updateVisibility();
   }
@@ -263,34 +304,51 @@ void Display::processMessage(const mrs_msgs::PoseWithCovarianceArrayStamped::Con
     disp_data.push_back(display_object());
     auto& d = disp_data.back();
 
-    d.arrow_ = boost::make_shared<rviz::Arrow>(scene_manager_, scene_node_, shaft_length_property_->getFloat(), shaft_radius_property_->getFloat(),
-                                          head_length_property_->getFloat(), head_radius_property_->getFloat());
-
     Ogre::ColourValue color = color_property_->getOgreColor();
     color.a                 = alpha_property_->getFloat();
-    d.arrow_->setColor(color);
 
-    d.axes_ = boost::make_shared<rviz::Axes>(scene_manager_, scene_node_, axes_length_property_->getFloat(), axes_radius_property_->getFloat());
+    switch (shape_property_->getOptionInt()){
+      case (Arrow):
+        d.arrow_ = boost::make_shared<rviz::Arrow>(scene_manager_, scene_node_, shaft_length_property_->getFloat(), shaft_radius_property_->getFloat(),
+            head_length_property_->getFloat(), head_radius_property_->getFloat());
 
-    d.covariance_ = covariance_property_->createAndPushBackVisual(scene_manager_, scene_node_);
+        d.arrow_->setColor(color);
 
-    d.axes_->setPosition(position);
-    d.axes_->setOrientation(orientation);
+        d.arrow_->setPosition(position);
+        d.arrow_->setOrientation(orientation * Ogre::Quaternion(Ogre::Degree(-90), Ogre::Vector3::UNIT_Y));
 
-    d.arrow_->setPosition(position);
-    d.arrow_->setOrientation(orientation * Ogre::Quaternion(Ogre::Degree(-90), Ogre::Vector3::UNIT_Y));
+        coll_handler_->addTrackedObjects(d.arrow_->getSceneNode());
+        break;
+      case (Axes):
+        d.axes_ = boost::make_shared<rviz::Axes>(scene_manager_, scene_node_, axes_length_property_->getFloat(), axes_radius_property_->getFloat());
 
-    d.covariance_->setPosition(position);
-    d.covariance_->setOrientation(orientation);
-    geometry_msgs::PoseWithCovariance pwc;
-    pwc.covariance = message->poses[i].covariance;
-    pwc.pose       = message->poses[i].pose;
-    d.covariance_->setCovariance(pwc);
+        d.axes_->setPosition(position);
+        d.axes_->setOrientation(orientation);
 
-    coll_handler_->addTrackedObjects(d.arrow_->getSceneNode());
-    coll_handler_->addTrackedObjects(d.axes_->getSceneNode());
-    coll_handler_->addTrackedObjects(d.covariance_->getPositionSceneNode());
-    coll_handler_->addTrackedObjects(d.covariance_->getOrientationSceneNode());
+        coll_handler_->addTrackedObjects(d.axes_->getSceneNode());
+        break;
+      default:
+        d.fast_arrow_ = boost::make_shared<rviz::FastArrow>(scene_manager_, scene_node_, shaft_length_property_->getFloat(), head_length_property_->getFloat(),
+            head_radius_property_->getFloat());
+        d.fast_arrow_->setColor(color);
+
+
+        d.fast_arrow_->setPosition(position);
+        d.fast_arrow_->setOrientation(orientation * Ogre::Quaternion(Ogre::Degree(-90), Ogre::Vector3::UNIT_Y));
+
+        coll_handler_->addTrackedObjects(d.fast_arrow_->getSceneNode());
+    }
+    if ( covariance_property_->getBool()){
+      geometry_msgs::PoseWithCovariance pwc;
+      pwc.covariance = message->poses[i].covariance;
+      pwc.pose       = message->poses[i].pose;
+      d.covariance_ = covariance_property_->createAndPushBackVisual(scene_manager_, scene_node_);
+      d.covariance_->setPosition(position);
+      d.covariance_->setOrientation(orientation);
+      d.covariance_->setCovariance(pwc);
+      coll_handler_->addTrackedObjects(d.covariance_->getPositionSceneNode());
+      coll_handler_->addTrackedObjects(d.covariance_->getOrientationSceneNode());
+    }
 
     context_->queueRender();
   }

--- a/src/smart_line/smart_line.cpp
+++ b/src/smart_line/smart_line.cpp
@@ -1,0 +1,32 @@
+ #include "smart_line/smart_line.h"
+ 
+ #include <sstream>
+ 
+ #include <OgreSceneNode.h>
+ #include <OgreSceneManager.h>
+ #include <OgreManualObject.h>
+ #include <OgreMaterialManager.h>
+ #include <OgreTechnique.h>
+ 
+ namespace rviz
+ {
+     void SmartLine::setColorUnshaded(const Ogre::ColourValue& c){
+       /* manual_object_material_->setLightingEnabled(false); */
+       manual_object_material_->setAmbient(c);
+       manual_object_material_->setDiffuse(c);
+       manual_object_material_->setSelfIllumination(c);
+       manual_object_material_->setShadingMode(Ogre::SO_FLAT);
+
+       if (c.a < 0.9998)
+       {
+         manual_object_material_->getTechnique(0)->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
+         manual_object_material_->getTechnique(0)->setDepthWriteEnabled(false);
+       }
+       else
+       {
+         manual_object_material_->getTechnique(0)->setSceneBlending(Ogre::SBT_REPLACE);
+         manual_object_material_->getTechnique(0)->setDepthWriteEnabled(true);
+       }
+     }
+ 
+ } // namespace rviz


### PR DESCRIPTION
Various changes that allow for displaying the `PoseWithCovarianceArray` message in RViz even in cases where the array is very large. I needed this for tuning a particle filter.
The visual objects (arrows, axes, covariance ellipsoids) will now only be created upon message reception if the given display element is allowed. Previously they were being instantiated even if they were hidden, causing unnecessary overhead.
I have also added a new display type for simple but fast pose illustration - the `FastArrow` indicator comprised of three unshaded lines, as an alternative to the shaded mesh `Arrow`.
If the covariance display is turned off and the `FastArrow` is selected, RViz can display many  (~1000) of input poses without much effort, where before it was lagging significantly.